### PR TITLE
Support Kubernetes

### DIFF
--- a/.testbox/config.yml
+++ b/.testbox/config.yml
@@ -1,7 +1,5 @@
 docker:
   build:
-    args:
-      BUNDLE_GITHUB__COM: <%= ENV['BUNDLE_GITHUB__COM'] %>
   workdir: /test
 scripts:
   ls: ls

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM ruby:2.5.1
+# syntax = docker/dockerfile:experimental
 
-ARG BUNDLE_GITHUB__COM
-ENV BUNDLE_GITHUB__COM=$BUNDLE_GITHUB__COM
+FROM ruby:2.5.1
 
 COPY . /test
 WORKDIR /test
-RUN bundle install
+
+RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN  --mount=type=ssh bundle install
 
 CMD [ "tail", "-f", "/dev/null" ]

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gem 'activesupport'
 gem 'pry'
 
 # /testbox is where the current testbox is mounted in the bookstore_test container
-gem 'testbox', path: File.exists?('/testbox') ? '/testbox' : '../../..'
+gem 'testbox', git: 'git@github.com:toptal/testbox.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
-PATH
-  remote: ../testbox
+GIT
+  remote: git@github.com:toptal/testbox.git
+  revision: 45e255be807c4fe6a9e696cde9dd06e182b27c37
   specs:
     testbox (0.0.1)
       childprocess
@@ -18,7 +19,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
-    childprocess (3.0.0)
+    childprocess (4.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     diff-lcs (1.3)
@@ -34,12 +35,12 @@ GEM
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     optimist (3.0.1)
-    os (1.1.0)
+    os (1.1.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rack (2.2.2)
-    rack-protection (2.0.8.1)
+    rack (2.2.3)
+    rack-protection (2.1.0)
       rack
     rchardet (1.8.0)
     rspec (3.9.0)
@@ -56,10 +57,10 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
     ruby2_keywords (0.0.2)
-    sinatra (2.0.8.1)
+    sinatra (2.1.0)
       mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.8.1)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
       tilt (~> 2.0)
     thread_safe (0.3.6)
     tilt (2.0.10)

--- a/spec/bookstore_spec.rb
+++ b/spec/bookstore_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe 'Bookstore API' do
   end
 
   describe 'Book title' do
-    it 'Should be upper case', skip: !feature_flags['bookstore_api']['upcase_titles'] do
+    it 'Should be upper case', skip: !feature_flags['bookstore-api']['upcase_titles'] do
       expect(AppClient.new.books.first['title']).to eq('MORFINA')
     end
 
-    it 'Should be regular case', skip: feature_flags['bookstore_api']['upcase_titles'] do
+    it 'Should be regular case', skip: feature_flags['bookstore-api']['upcase_titles'] do
       expect(AppClient.new.books.first['title']).to eq('Morfina')
     end
   end

--- a/spec/support/app_client.rb
+++ b/spec/support/app_client.rb
@@ -2,7 +2,7 @@ require 'faraday'
 require 'json'
 
 class AppClient
-  def initialize(url = 'http://bookstore_api:3000')
+  def initialize(url = 'http://bookstore-api:3000')
     @url = url
   end
 

--- a/spec/support/testbox_helper.rb
+++ b/spec/support/testbox_helper.rb
@@ -4,19 +4,19 @@ require 'testbox/web/client'
 class TestboxHelper
   attr_reader :client
 
-  def initialize(url = nil)
+  def initialize(url = 'http://testbox:4567')
     @client = Testbox::Web::Client.new(url)
   end
 
   def db_migrate
-    client.execute(components: ['bookstore_api'], command: 'rails db:migrate')
+    client.execute(components: ['bookstore-api'], command: 'rails db:migrate')
   end
 
   def db_reset
-    client.execute(components: ['bookstore_api'], command: 'rails db:reset')
+    client.execute(components: ['bookstore-api'], command: 'rails db:reset')
   end
 
   def feature_flags
-    JSON.parse(client.execute(components: ['bookstore_api'], action: 'feature_flags')['stdout'])
+    JSON.parse(client.execute(components: ['bookstore-api'], action: 'feature_flags')['stdout'])
   end
 end


### PR DESCRIPTION
1. Enable token-less installation of Testbox gem.
2. Uses dashes in service names since Kubernetes doesn't like underscores.
3. Uses Testbox sidecar container instead of host for communication.

https://github.com/toptal/testbox/pull/24