### PR TITLE
Create a faketime-enabled image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 # syntax = docker/dockerfile:experimental
 
-FROM ruby:2.5.1
+FROM gcr.io/compute-engine-1069/ruby:2.5.3-centos as ruby-base
+
+# chromedriver
+RUN yum -y install curl unzip xvfb libxi6 libgconf-2-4 openssh-clients git
+RUN yum -y install --enablerepo=nodesource,yarn,epel,toptal libexif dejavu-sans-fonts dejavu-serif-fonts dejavu-sans-mono-fonts \
+     liberation-fonts-common liberation-sans-fonts x11vnc xorg-x11-server-Xvfb google-cloud-sdk \
+     google-chrome-stable
+RUN uuidgen | tr -d - > /etc/machine-id
 
 COPY . /test
 WORKDIR /test


### PR DESCRIPTION
Required for [this to work](https://github.com/toptal/testbox/pull/28)

* Using CentOS, like Platform does
* Adding Google Chrome install

```
cd testbox/sandbox
rm -rf apps/*
# ensure testbox uses the faketime-fix branch by tweaking testbox.yml
bundle exec testbox init && bundle exec testbox build all
```
